### PR TITLE
capitalize GUI consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #go, #golang, #gui, #gioui
 ```
 
-You want a Gui. Of course you do. 
+You want a GUI. Of course you do. 
 
 Did you know that Go has a great GUI library called [Gio](https://gioui.org/)? In a [10-part tutorial](https://jonegil.github.io/gui-with-gio/egg_timer/) we will start completely from scratch, with zero background required, and build a self contained GUI application:
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: Gui with Gio
-description: Delightful Gui in Go
+title: GUI with Gio
+description: Delightful GUI in Go
 show_downloads: false
 remote_theme: pmarsceill/just-the-docs
 

--- a/egg_timer/01_empty_window.md
+++ b/egg_timer/01_empty_window.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Chapter 1 - Window 
+title: Chapter 1 - Window
 nav_order: 2
 parent: Egg timer
 has_children: false
@@ -9,21 +9,24 @@ has_children: false
 # Chapter 1 - An empty window
 
 ## Goals
-The intention of this section is to create a blank canvas that we later can draw upon. 
+
+The intent of this section is to create a blank canvas that we later can draw upon.
 
 ![An empty window](01_empty_window.gif)
 
 ## Outline
 
 The code does three main things:
- - Imports Gio
- - Creates and calls a goroutine that: 
-   - Creates a new window, called `w`
-   - Starts a never-ending loop that waits for Events in the window (no Event will ever occur in this example)
+
+- Imports Gio
+- Creates and calls a goroutine that:
+  - Creates a new window, called `w`
+  - Starts a never-ending loop that waits for Events in the window (no Event will ever occur in this example)
 
 That's it! Let's look at the code:
 
 ## Code
+
 ```go
 package main
 
@@ -48,37 +51,39 @@ func main() {
 
 The code looks simple enough, right? Still, let's take the time to to look at what's going on.
 
-1. We import ```gioui.org/app```. What's that?
-   
-   Looking at [the docs](https://pkg.go.dev/gioui.org/app) we find:
-   > *Package app provides a platform-independent interface to operating system functionality for running graphical user interfaces.*
-   
-   This is good news. Gio takes care of all the platform dependent stuff for us. I routinely code on Windows and MacOS. Gio just works. [GioUI.org](https://gioui.org/#installation) lists even more, iOS and Android included.
-   
-   This is deeper than you might realize. Even if your app today is single-platform, your *skillset* is now multi-platform. 
-   *"We should port to Mac."* &nbsp;Consider it done! *"Hot startup seeking app and desktop experts.*" &nbsp;No problem. *"Who here knows tvOS?"* &nbsp;You do!
-   *"The pilot died, can anyone land this plane?!*" &nbsp;OK, maybe not that last one but the point still stands. The diversity of Gio is nothing less than amazing.
-   
-2. The **event loop** in the goroutine
-   
-   - The event loop is the `for range w.Events()` loop that listens for events in the window. For now we just let it listen without doing anything with the events it receives. Later we'll start reacting to them.
-   
-     From [app.main](https://pkg.go.dev/gioui.org/app#hdr-Main) we learn:
-     > *Because Main is also blocking on some platforms, the event loop of a Window must run in a goroutine.*
+1.  We import `gioui.org/app`. What's that?
 
-    - A goroutine with no name (i.e. an *anonymous function*) is created and runs the event loop. Since it's in a goroutine it will spin concurrently with the rest of the program.
-   ```go
-go func {
-  // ...
-}()
-   ```
-  
-      Jeremy Bytes [writes well about anonymous functions](https://jeremybytes.blogspot.com/2021/02/go-golang-anonymous-functions-inlining.html). They're useful in many contexts, not only with Gio.
+    Looking at [the docs](https://pkg.go.dev/gioui.org/app) we find:
 
+    > _Package app provides a platform-independent interface to operating system functionality for running graphical user interfaces._
 
-3. Start it by calling ```app.Main()```
-From [app.Main documentation](https://pkg.go.dev/gioui.org/app#hdr-Main):
-   > *The Main function must be called from a program's main function, to hand over control of the main thread to operating systems that need it.*
+    This is good news. Gio takes care of all the platform dependent stuff for us. I routinely code on Windows and MacOS. Gio just works. [GioUI.org](https://gioui.org/#installation) lists even more, iOS and Android included.
+
+    This is deeper than you might realize. Even if your app today is single-platform, your _skillset_ is now multi-platform.
+    _"We should port to Mac."_ &nbsp;Consider it done! _"Hot startup seeking app and desktop experts._" &nbsp;No problem. _"Who here knows tvOS?"_ &nbsp;You do!
+    _"The pilot died, can anyone land this plane?!_" &nbsp;OK, maybe not that last one but the point still stands. The diversity of Gio is nothing less than amazing.
+
+2.  The **event loop** in the goroutine
+
+    - The event loop is the `for range w.Events()` loop that listens for events in the window. For now we just let it listen without doing anything with the events it receives. Later we'll start reacting to them.
+
+      From [app.main](https://pkg.go.dev/gioui.org/app#hdr-Main) we learn:
+
+      > _Because Main is also blocking on some platforms, the event loop of a Window must run in a goroutine._
+
+    - A goroutine with no name (i.e. an _anonymous function_) is created and runs the event loop. Since it's in a goroutine it will spin concurrently with the rest of the program.
+
+    ```go
+    go func {
+    // ...
+    }()
+    ```
+
+          Jeremy Bytes [writes well about anonymous functions](https://jeremybytes.blogspot.com/2021/02/go-golang-anonymous-functions-inlining.html). They're useful in many contexts, not only with Gio.
+
+3.  Start it by calling `app.Main()`
+    From [app.Main documentation](https://pkg.go.dev/gioui.org/app#hdr-Main):
+    > _The Main function must be called from a program's main function, to hand over control of the main thread to operating systems that need it._
 
 ---
 

--- a/egg_timer/02_title_and_size.md
+++ b/egg_timer/02_title_and_size.md
@@ -1,23 +1,25 @@
 ---
 layout: default
-title: Chapter 2 - Title 
+title: Chapter 2 - Title
 nav_order: 2
 parent: Egg timer
-has_children: false 
+has_children: false
 ---
 
 # Chapter 2 - Title and size
 
 ## Goals
-The intention of this section is to set a custom title and fixate the size of the window.
+
+The intent of this section is to set a custom title and the size of the window.
 
 ![Window with custom title and set size](02_title_and_size.png)
 
 ## Outline
 
-The code is very similar to that of [chapter 1](01_empty_window). We add
- - one more import 
- - two parameters when calling ```app.NewWindow()```
+This code is very similar to that of [chapter 1](01_empty_window.md). We add:
+
+- one more import
+- two parameters when calling `app.NewWindow()`
 
 ## Code
 
@@ -25,49 +27,48 @@ The code is very similar to that of [chapter 1](01_empty_window). We add
 package main
 
 import (
-  "gioui.org/app"
-  "gioui.org/unit"
+	"gioui.org/app"
+	"gioui.org/unit"
 )
 
 func main() {
-go func() {
-// create new window
-    w := app.NewWindow(
-      app.Title("Egg timer"),
-      app.Size(unit.Dp(400), unit.Dp(600)),
-    )
+  go func() {
+	// create new window
+	w := app.NewWindow(
+		app.Title("Egg timer"),
+		app.Size(unit.Dp(400), unit.Dp(600)),
+	)
 
-    // listen for events in the window.
-    for range w.Events() {
-    }
+	// listen for events in the window.
+	for range w.Events() {
+	}
   }()
-  app.Main()
+app.Main()
 }
-
 ```
 
 ## Comments
 
 [gioui.org/unit](https://pkg.go.dev/gioui.org/unit) implements device independent units and values. The docs describe a handful of alternatives:
 
-| Type | Description                                                      |
-| dp   | Device independent pixel - independent of the underlying device. |
-| sp   | Scaled pixel - used for text sizes                               |
-| px   | Pixels - used for precision for the actual device                |
- 
-In general, ```dp``` is most used. Also, let's keep device independency when we can. Hence that's what we use when we define the window size inside ```app.NewWindow()```
+| Type | Description                                                     |
+| :--: | :-------------------------------------------------------------- |
+|  dp  | Device independent pixel - independent of the underlying device |
+|  sp  | Scaled pixel - used for text sizes                              |
+|  px  | Pixels - used for precision for the actual device               |
 
-The [options](https://pkg.go.dev/gioui.org/app#Option) of ```app.NewWindow()``` are fairly self-explanatory. Some comments though:
+In general, `dp` is the most widely used; we like to keep device independency when we can. Hence that's what we use when we define the window size inside `app.NewWindow()`.
 
- - Note how size is set as ```app.Size(x, y)```.
- - The window can be freely resized. Try it. If you want to limit it, you can add
-   - MaxSize
-   - MinSize
-   - Both, effectively locking the window size 
+The [options](https://pkg.go.dev/gioui.org/app#Option) of `app.NewWindow()` are fairly self-explanatory, but take note of a few things:
 
- - There's also a Fullscreen option if you need.
- - If you're building for Android, Status and Navigation colors can be set here. 
- 
+- The size is set using `app.Size(x, y)`.
+- The window can be freely resized. Try it! If you want to limit the size you can add:
+  - MaxSize
+  - MinSize
+  - Or use both, effectively locking the window size
+- A fullscreen option is available if needed.
+- If you're building for Android, Status and Navigation colors can be set here.
+
 ---
 
 [Next chapter](03_button.md){: .btn .fs-5 .mb-4 .mb-md-0 }

--- a/egg_timer/03_button.md
+++ b/egg_timer/03_button.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 3 - Button 
 
 ## Goals
-The intention of this section is to add a button. Not only can we click it, but it will have a nice hover and click animations.
+The intent of this section is to add a button. Not only can we click it, but it will have a nice hover and click animations.
 
 ![A button](03_button.gif)
 

--- a/egg_timer/05_button_low_refactored.md
+++ b/egg_timer/05_button_low_refactored.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 5 - Low button refactored
 
 ## Goals
-The intention of this section is to organize the code better. 
+The intent of this section is to organize the code better. 
 
 ## Outline
 

--- a/egg_timer/06_button_low_margin.md
+++ b/egg_timer/06_button_low_margin.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 6 - Low button with margin
 
 ## Goals
-The intention of this chapter is to add open space around all sides of the button.
+The intent of this chapter is to add open space around all sides of the button.
 
 ![Button with margin](06_button_low_margin.png)
 

--- a/egg_timer/07_progressbar.md
+++ b/egg_timer/07_progressbar.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 7 - Progressbar
 
 ## Goals
-The intention of this section is to add a progressbar
+The intent of this section is to add a progressbar
 
 ![Progressbar](07_progressbar.gif)
 

--- a/egg_timer/08_egg_as_circle.md
+++ b/egg_timer/08_egg_as_circle.md
@@ -9,28 +9,32 @@ has_children: false
 # Chapter 8 - Custom graphics - a circle
 
 ## Goals
-The intention of this section is to draw custom graphics that (vaguely) resembles an egg
+
+The intent of this section is to draw custom graphics that (vaguely) resembles an egg
 
 ![Egg as circle](08_egg_as_circle.gif)
 
 ## Outline
 
-The code introduces custom graphics. The circle in the app is drawn by Gio, not displaying a static picture. Tho achieve that we combine 
- - A **clip** to define the area we can draw within
- - A **paint** operation to fill that area
- - Some parameters to set color
- 
+The code introduces custom graphics. The circle in the app is drawn by Gio, not displaying a static picture. Tho achieve that we combine
+
+- A **clip** to define the area we can draw within
+- A **paint** operation to fill that area
+- Some parameters to set color
+
 ## Imports
 
 There are some new imports, namely
- - [image](https://pkg.go.dev/image) and [image/color](https://blog.golang.org/image/color), Go's standard 2D image library.
-   - Nigel Tao [writes well](https://blog.golang.org/image) about these packages on the Go blog.
 
- - [f32](https://pkg.go.dev/gioui.org/f32). Go's image library is based on ```int```, while Gio prefers to work with ```float32```. Hence f32 reimplements floating point versions of the two main types, ```Points``` and ```Rectangles```
- 
- - [op/clip](https://pkg.go.dev/gioui.org/op/clip) is used to define an area to paint within. Drawing outside this area is ignored.
+- [image](https://pkg.go.dev/image) and [image/color](https://blog.golang.org/image/color), Go's standard 2D image library.
 
- - [op/paint](https://pkg.go.dev/gioui.org/op/paint) contains drawing operations to fill a shape with color.
+  - Nigel Tao [writes well](https://blog.golang.org/image) about these packages on the Go blog.
+
+- [f32](https://pkg.go.dev/gioui.org/f32). Go's image library is based on `int`, while Gio prefers to work with `float32`. Hence f32 reimplements floating point versions of the two main types, `Points` and `Rectangles`
+
+- [op/clip](https://pkg.go.dev/gioui.org/op/clip) is used to define an area to paint within. Drawing outside this area is ignored.
+
+- [op/paint](https://pkg.go.dev/gioui.org/op/paint) contains drawing operations to fill a shape with color.
 
 ## Points and Rectangles
 
@@ -48,6 +52,7 @@ type Rectangle struct {
 
 A Point is an X, Y coordinate pair. The axes increase right and down (origin = top left corner). It is neither a pixel nor a grid square. A Point has no intrinsic width, height or color, but the visualizations below use a small colored square.
 ![Point](08_image_package_point.png)
+
 ```go
 p := f32.Point{2, 1}
 ```
@@ -55,12 +60,13 @@ p := f32.Point{2, 1}
 A Rectangle contains the points with Min.X <= X < Max.X, Min.Y <= Y < Max.Y. It has no intrinsic color, but the visualization below outlines it with a thin colored line, and call out their Min and Max Points.
 
 ![Rectangle](08_image_package_rectangle.png)
+
 ```go
 r := f32.Rect(2, 1, 5, 5)
 ```
 
-For convenience, image.Rect(x0, y0, x1, y1) is equivalent to ```Rectangle{Point{x0, y0}, Point{x1, y1}}```, but is much easier to type. It also swaps Minimum and Maximum to ensure it's well formed.
-   
+For convenience, image.Rect(x0, y0, x1, y1) is equivalent to `Rectangle{Point{x0, y0}, Point{x1, y1}}`, but is much easier to type. It also swaps Minimum and Maximum to ensure it's well formed.
+
 That's it. Let's look at the code:
 
 ## Code
@@ -85,18 +91,18 @@ layout.Rigid(
 
 ## Comments
 
-We first define a circle using ```clip.Circle{ }```. It defines the Center point and Radius. 
+We first define a circle using `clip.Circle{ }`. It defines the Center point and Radius.
 
-The origin of the circle is hard-coded, with distance from the top left corner of the *widget*. Note that this is *not* necessarily the top left corner of the app. The size of the widget itself is coded as
-```Dimensions``` using ```d := image.Point{Y: 500}```. X represents width and Y represents Height
+The origin of the circle is hard-coded, with distance from the top left corner of the _widget_. Note that this is _not_ necessarily the top left corner of the app. The size of the widget itself is coded as
+`Dimensions` using `d := image.Point{Y: 500}`. X represents width and Y represents Height
 
-You can play around with these dimensions, familiarizing yourself with when the circle moves up or down, depending in wheiter you resize the box or move the circle center inside the box. Also, try commenting the hard-coded and uncomment the soft coding below that uses the window area as a reference. 
+You can play around with these dimensions, familiarizing yourself with when the circle moves up or down, depending in wheiter you resize the box or move the circle center inside the box. Also, try commenting the hard-coded and uncomment the soft coding below that uses the window area as a reference.
 
-```color.NRGBA``` defines the color of the circle. Note that the Alpha-channel defaults to 0, i.e. invisible, so we lift it to 255 so we can actually see it.
+`color.NRGBA` defines the color of the circle. Note that the Alpha-channel defaults to 0, i.e. invisible, so we lift it to 255 so we can actually see it.
 
-```paint.FillShape``` fills the shape with the ```color```.
+`paint.FillShape` fills the shape with the `color`.
 
-And finally we return the widget in the form of its ```Dimensions```, height: 400.
+And finally we return the widget in the form of its `Dimensions`, height: 400.
 
 ---
 

--- a/egg_timer/09_egg_as_egg.md
+++ b/egg_timer/09_egg_as_egg.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 9 - Egg as egg
 
 ## Goals
-The intention of this section is to draw an actual egg.
+The intent of this section is to draw an actual egg.
 
 ![An actual egg](09_egg_as_egg.gif)
 

--- a/egg_timer/10_input_boiltime.md
+++ b/egg_timer/10_input_boiltime.md
@@ -9,7 +9,7 @@ has_children: false
 # Chapter 10 - Set the boiltime
 
 ## Goals
-The intention of this section is to add an input field to set the boiltime.
+The intent of this section is to add an input field to set the boiltime.
 
 ![The complete egg timer](egg_timer.gif)
 

--- a/egg_timer/11_improved_animation.md
+++ b/egg_timer/11_improved_animation.md
@@ -9,36 +9,37 @@ has_children: false
 # Bonus material - Animation
 
 ## Goals
-The intention of this section is to discuss a slightly more advanced topic related to animation, namely how and when we invalidate a frame, what that actually means, and how to code well with it. 
+
+The intent of this section is to discuss a slightly more advanced topic related to animation, namely how and when we invalidate a frame, what that actually means, and how to code well with it.
 
 ![The complete egg timer](egg_timer.gif)
 
 ## Outline
 
 The outline of this bonus chapter is as follows:
- - First we discuss what it means to invalidate a frame
- - Then we look at two different method calls to do so
- - Finally we discuss an alternative pattern to generate and control animation
 
+- First we discuss what it means to invalidate a frame
+- Then we look at two different method calls to do so
+- Finally we discuss an alternative pattern to generate and control animation
 
 ### 1. What is Invalidate?
 
 Gio only updates what you see when a [FrameEvent](https://pkg.go.dev/gioui.org/io/system#FrameEvent) is generated. This can be for example when a key is pressed, mouse is clicked, widget receives or loses focus. That makes perfect sense, with refresh rates of up to 120 frames per second for modern devices, chances are that what should be displayed quite often is identical to the last frame.
 
-Quite often. But not always. 
+Quite often. But not always.
 
-One exception to this rule is animation. When animating, you want it to run as smooth as possible. To achieve this, we need to ask Gio to redraw continuously. And without triggering events we need to explicitly tell Gio to do so. That is done by calling ```invalidate```.
+One exception to this rule is animation. When animating, you want it to run as smooth as possible. To achieve this, we need to ask Gio to redraw continuously. And without triggering events we need to explicitly tell Gio to do so. That is done by calling `invalidate`.
 
 ### 2. To ways to invalidate
 
 There are two alternatives, let's look at both:
 
-- [op.InvalidateOp{}.Add(ops)](https://pkg.go.dev/gioui.org/op#InvalidateOp) is the most efficient, and can be used to request an immediate or future redraw ```At time.Time```.
+- [op.InvalidateOp{}.Add(ops)](https://pkg.go.dev/gioui.org/op#InvalidateOp) is the most efficient, and can be used to request an immediate or future redraw `At time.Time`.
 - [window.Invalidate](https://pkg.go.dev/gioui.org/app#Window.Invalidate) is less efficient, and intended for externally triggered events. But it's also the right option if you want to invalidate outside of layout code. One example of that is in [Chapter 7 - Animation](07_progressbar.html) where we had a separate tick-generator.
 
 #### Example 1 - op.InvalidateOp{}
 
-To showcase ```op.InvaliateOp{}.Add(ops)``` we'll quote the well written animation example from the [architecture document](https://gioui.org/doc/architecture#animation):
+To showcase `op.InvaliateOp{}.Add(ops)` we'll quote the well written animation example from the [architecture document](https://gioui.org/doc/architecture#animation):
 
 ```go
 // Source: https://gioui.org/doc/architecture#animation
@@ -67,12 +68,11 @@ func drawProgressBar(ops *op.Ops, now time.Time) {
 }
 ```
 
-Depending on the complexity of your layouts, this one might push your machine a bit. However, with [improved caching](https://lists.sr.ht/~eliasnaur/gio/%3CCD3XWVXUTCG0.23LAQED4PF674%40themachine%3E) that system load is reduced. If that works for your application you are good to go. 
-
+Depending on the complexity of your layouts, this one might push your machine a bit. However, with [improved caching](https://lists.sr.ht/~eliasnaur/gio/%3CCD3XWVXUTCG0.23LAQED4PF674%40themachine%3E) that system load is reduced. If that works for your application you are good to go.
 
 #### Example 2 - w.Invalidate()
 
-If however you prefer to set the framerate using a central ticking ```progressIncrementer```, there's an example of ```w.Invalidate()``` from [Chapter 7 - Animation](07_progressbar.html), and one in [kitchen](https://github.com/gioui/gio-example/blob/main/kitchen/kitchen.go) from the front page of gioui.org. To repeat the former:
+If however you prefer to set the framerate using a central ticking `progressIncrementer`, there's an example of `w.Invalidate()` from [Chapter 7 - Animation](07_progressbar.html), and one in [kitchen](https://github.com/gioui/gio-example/blob/main/kitchen/kitchen.go) from the front page of gioui.org. To repeat the former:
 
 ```go
 func main() {
@@ -105,7 +105,7 @@ func draw(w *app.Window) error {
 
 #### Example 3 - Replacing w.Invalidate() with op.InvalidateOp{} - what's the effect
 
-Can do better than that? Why not use the ```IncrementOp{At time.Time}``` instead of the central ticker? We need to move it into the ```Layout``` section inside FrameEvent. Here's how that rigid would look:
+Can do better than that? Why not use the `IncrementOp{At time.Time}` instead of the central ticker? We need to move it into the `Layout` section inside FrameEvent. Here's how that rigid would look:
 
 ```go
 // The progressbar
@@ -121,11 +121,11 @@ layout.Rigid(
 
 ```
 
-Take a look in the code for the animation. You'll find the above ```op.InvalidateOp{}``` on [line 201](https://github.com/jonegil/gui-with-gio/blob/fc54ae4394fe92f79934e816bf54ac800e703daa/egg_timer/code/11_improved_animation/main.go#L201), and the old ```w.Invalidate()``` on [line 255](https://github.com/jonegil/gui-with-gio/blob/fc54ae4394fe92f79934e816bf54ac800e703daa/egg_timer/code/11_improved_animation/main.go#L255). Try changing running either one or the other to see which one performs best.
+Take a look in the code for the animation. You'll find the above `op.InvalidateOp{}` on [line 201](https://github.com/jonegil/gui-with-gio/blob/fc54ae4394fe92f79934e816bf54ac800e703daa/egg_timer/code/11_improved_animation/main.go#L201), and the old `w.Invalidate()` on [line 255](https://github.com/jonegil/gui-with-gio/blob/fc54ae4394fe92f79934e816bf54ac800e703daa/egg_timer/code/11_improved_animation/main.go#L255). Try changing running either one or the other to see which one performs best.
 
-To try it out I ran three 60 second boils, one with each Invalidate method, both on my Macbook and my Windows desktop. On the Mac one was run with the old renderer, and one with the new using ```GIORENDERER=forcecompute go run main.go```.
+To try it out I ran three 60 second boils, one with each Invalidate method, both on my Macbook and my Windows desktop. On the Mac one was run with the old renderer, and one with the new using `GIORENDERER=forcecompute go run main.go`.
 
-Without forcecompute the 2017 Macbook Air runs ```op.InvalidateOp{}``` at about 16-17% CPU, while ```w.Invalidate()``` consumes around 18-19%. Those levels drop to ca 12% and 15% with the compute renderer. The level is fairly high, but the difference is not that large. Still it's worth knowing the effect of each invalidate technique. On my Windows machine the load is much smaller with no meaningful difference between the two techniques.
+Without forcecompute the 2017 Macbook Air runs `op.InvalidateOp{}` at about 16-17% CPU, while `w.Invalidate()` consumes around 18-19%. Those levels drop to ca 12% and 15% with the compute renderer. The level is fairly high, but the difference is not that large. Still it's worth knowing the effect of each invalidate technique. On my Windows machine the load is much smaller with no meaningful difference between the two techniques.
 
 ![Invalidate CPU load](11_invalidate_cpu_load.png)
 
@@ -133,13 +133,14 @@ Without forcecompute the 2017 Macbook Air runs ```op.InvalidateOp{}``` at about 
 
 My friend Chris Waldon came through with this pattern:
 
-> *In my Gio applications, I have found a pattern that I think works well for encapsulating animation logic. It allows you to hide the management of the invalidation behind an API, and to compute the progress as a function of time. It eliminates the ticker goroutine altogether, though I almost worry that it makes the app less cool.*
+> _In my Gio applications, I have found a pattern that I think works well for encapsulating animation logic. It allows you to hide the management of the invalidation behind an API, and to compute the progress as a function of time. It eliminates the ticker goroutine altogether, though I almost worry that it makes the app less cool._
 
 Sound's intriguing, right? You can find the raw code in [his repo](https://github.com/whereswaldon/gui-with-gio/commit/83e43a39e75c5e6cb96985046a521ac553615d39), but let's examine it a bit here too:
 
 #### An animation struct
 
-First replace the state variables ```boiling``` and ```boilDuration``` with a struct that knows when we started, and how long it should take:
+First replace the state variables `boiling` and `boilDuration` with a struct that knows when we started, and how long it should take:
+
 ```go
 // animation tracks the progress of a linear animation across multiple frames.
 type animation struct {
@@ -150,10 +151,11 @@ type animation struct {
 var anim animation
 ```
 
-This allows us to create methods to animate next frame and eventually end the animation. 
-This is where ```op.InvalidateOp{}.Add()``` is called. 
+This allows us to create methods to animate next frame and eventually end the animation.
+This is where `op.InvalidateOp{}.Add()` is called.
 
-Also, note how it uses ```gtx.Now``` instead of ```time.Now```, most importantly ensuring the animation is synchronized, but also avoids some overhead from ```time.Now```. 
+Also, note how it uses `gtx.Now` instead of `time.Now`, most importantly ensuring the animation is synchronized, but also avoids some overhead from `time.Now`.
+
 ```go
 // animate starts an animation at the current frame which will last for the provided duration.
 func (a *animation) animate(gtx layout.Context, duration time.Duration) {
@@ -168,8 +170,9 @@ func (a *animation) stop() {
 }
 ```
 
-Finally a method to report on progress: 
-- Are we still animating? 
+Finally a method to report on progress:
+
+- Are we still animating?
 - And if so, how much is done?
 
 ```go
@@ -183,8 +186,11 @@ func (a animation) progress(gtx layout.Context) (animating bool, progress float3
 }
 
 ```
+
 #### Start simplifying
-With that in place we can simplify the ```startButton.Clicked()``` code to:
+
+With that in place we can simplify the `startButton.Clicked()` code to:
+
 ```go
 case system.FrameEvent:
   gtx := layout.NewContext(&ops, e)
@@ -207,7 +213,7 @@ case system.FrameEvent:
 
 #### Tidy up the loose end
 
-At the, since we removed the ```boilDuration``` variable, we instead use ```anim.duration.Seconds()```:
+At the, since we removed the `boilDuration` variable, we instead use `anim.duration.Seconds()`:
 
 ```go
 // Count down the text when boiling
@@ -217,12 +223,12 @@ if boiling && progress < 1 {
 
 #### What about our ticker-channel?
 
-All code related to the ```progressIncrementer``` channel, both variables, reading and writing to the chan, is removed.
+All code related to the `progressIncrementer` channel, both variables, reading and writing to the chan, is removed.
 
 We're not going into more detail about the pattern here, but know it exists and has some pretty neat functionality that takes care of state and status for your animation.
 
 ## Comments
 
-Summing it all up, I hope this has shed some more light on the in's and out's of animation in Gio. As so often, it depends what's the best solution. Showcasing a demo to impress? Go for smoothness. Minimizing work? Go for animation in steps. High end vs low end user hardware? Splurge or conserve as you see fit. 
+Summing it all up, I hope this has shed some more light on the in's and out's of animation in Gio. As so often, it depends what's the best solution. Showcasing a demo to impress? Go for smoothness. Minimizing work? Go for animation in steps. High end vs low end user hardware? Splurge or conserve as you see fit.
 
 Just be conscious about the trade-offs and know some of the techniques that can assist.

--- a/egg_timer/index.md
+++ b/egg_timer/index.md
@@ -13,7 +13,7 @@ has_toc: false
 Over the next 10 steps we will
 
  - Start completely from scratch
- - Code a stand-alone Go application with a gui using the Gio toolkit
+ - Code a stand-alone Go application with a GUI using the Gio toolkit
  - Take our time and explain each step along the way
 
 ![Egg timer](egg_timer.gif)

--- a/index.md
+++ b/index.md
@@ -3,13 +3,13 @@ title: Overview
 nav_order: 1
 has_children: false
 ---
-# Let's build a Gui with Gio
+# Let's build a GUI with Gio
 
 ```go
 #go, #golang, #gui, #gioui
 ```
 
-**You want a Gui. Of course you do.**
+**You want a GUI. Of course you do.**
 
 Did you know that Go has a great GUI library called [Gio](https://gioui.org/)? In this [10-part tutorial](egg_timer/index.md) we will start completely from scratch — with zero background required — and build a self-contained GUI application.
 

--- a/teleprompter/01_setup.md
+++ b/teleprompter/01_setup.md
@@ -82,10 +82,10 @@ To allow enough space after the line so that it actually scrolls off screeen, we
 
 ## Section 3 - Start the application 
 
-The last section of ```main``` starts the Gui in a normal manner:
+The last section of ```main``` starts the GUI in a normal manner:
 ```go
   // ... continuing inside main()
-  // Part 2 - Start the gui
+  // Part 2 - Start the GUI
   go func() {
     // create new window
     w := app.NewWindow(

--- a/teleprompter/code/main.go
+++ b/teleprompter/code/main.go
@@ -50,7 +50,7 @@ func main() {
 	   }
 	*/
 
-	// Part 2 - Start the gui
+	// Part 2 - Start the GUI
 	go func() {
 		// create new window
 		w := app.NewWindow(


### PR DESCRIPTION
Being consistent with words / abbreviations is recommended. 

Markdown (MD) tables should have a dashed line separating "header" columns from "body"; they render better.

MD uses triple backticks ONLY for entire codeblocks (```go). When referencing a keyword like `defer`, just use single backticks.

The words "intent" and "intention" are REALLY close, almost interchangeable. I've switched to "intent" for the following reasons:
1. As used in the Goal section, the words "intention" and "section" — both ending in "tion" — just don't flow.
2. Intention is usually when a __person__ wants to do something. This tutorial is a more formal thing and "intent" is more formal than familiar.

Link was missing its extension, but magically was still working? LOL

Other "flow" changes, nothing major worth mentioning.

Only got excited (!) in one place, I promise LOL