### PR TITLE
Degree to Radian Conversion

### DIFF
--- a/egg_timer/09_egg_as_egg.md
+++ b/egg_timer/09_egg_as_egg.md
@@ -37,7 +37,7 @@ layout.Rigid(
       // Egg math (really) at this brilliant site. Thanks!
       // https://observablehq.com/@toja/egg-curve
       // Convert degrees to radians
-      rad := deg / 360 * 2 * math.Pi
+      rad := deg * math.Pi / 180
       // Trig gives the distance in X and Y direction
       cosT := math.Cos(rad)
       sinT := math.Sin(rad)

--- a/egg_timer/code/09_egg_as_egg/main.go
+++ b/egg_timer/code/09_egg_as_egg/main.go
@@ -105,7 +105,7 @@ func draw(w *app.Window) error {
 							// Egg math (really) at this brilliant site. Thanks!
 							// https://observablehq.com/@toja/egg-curve
 							// Convert degrees to radians
-							rad := deg / 360 * 2 * math.Pi
+							rad := deg * math.Pi / 180
 							// Trig gives the distance in X and Y direction
 							cosT := math.Cos(rad)
 							sinT := math.Sin(rad)

--- a/egg_timer/code/10_input_boiltime/main.go
+++ b/egg_timer/code/10_input_boiltime/main.go
@@ -129,7 +129,7 @@ func draw(w *app.Window) error {
 						// rotate from zero to 360 deg
 						for deg := 0.0; deg <= 360; deg++ {
 							// covert degrees to radians
-							rad := deg / 360 * 2 * math.Pi
+							rad := deg * math.Pi / 180
 
 							// trigger gives the distance in X and Y direction
 							cosT := math.Cos(rad)

--- a/egg_timer/code/11_improved_animation/main.go
+++ b/egg_timer/code/11_improved_animation/main.go
@@ -129,7 +129,7 @@ func draw(w *app.Window) error {
 							// Egg math (really) at this brilliant site. Thanks!
 							// https://observablehq.com/@toja/egg-curve
 							// Convert degrees to radians
-							rad := deg / 360 * 2 * math.Pi
+							rad := deg * math.Pi / 180
 							// Trig gives the distance in X and Y direction
 							cosT := math.Cos(rad)
 							sinT := math.Sin(rad)


### PR DESCRIPTION
Replaced 'deg / 360 * 2 * math.Pi' with 'deg * math.Pi / 180' for easy readability.