### PR TITLE
Fixed 07_progressbar.md

### DIFF
--- a/egg_timer/07_progressbar.md
+++ b/egg_timer/07_progressbar.md
@@ -67,10 +67,10 @@ We mentioned `progress`, the variable that contains progress state. Another usef
 // is the egg boiling?
 var boiling bool
 ```
-We want to flip that boolean when the start button is clicked. Thus we listen for a `app.FrameEvent` from the GUI and check if `startButton.Clicked()` is true:
+We want to flip that boolean when the start button is clicked. Thus we listen for a `app.FrameEvent` from the GUI and check if `startButton.Clicked()` is true by updating our FrameEvent case:
 
 ```go
-case system.FrameEvent:
+case app.FrameEvent:
   gtx := layout.NewContext(&ops, e)
   // Let's try out the flexbox layout concept
   if startButton.Clicked(gtx) {


### PR DESCRIPTION
Fixed an error in the code given for the state update section. Students may think this is a separate case from the app.FrameEvent mentioned before and add it to the switch. Thus, it introduces a new variable "system" that is not defined and throws an error.