### PR TITLE
Update 08_egg_as_circle.md

### DIFF
--- a/egg_timer/08_egg_as_circle.md
+++ b/egg_timer/08_egg_as_circle.md
@@ -32,15 +32,15 @@ There are some new imports, namely
 
   - Nigel Tao [writes well](https://blog.golang.org/image) about these packages on the Go blog.
 
-- [f32](https://pkg.go.dev/gioui.org/f32). Go's image library is based on `int`, while Gio for some of its functions works with `float32`. Hence f32 reimplements floating point versions of the two main types, `Points` and `Rectangles`.
+- [gioui.org/f32](https://pkg.go.dev/gioui.org/f32). Go's image library is based on `int`, while Gio for some of its functions works with `float32`. Hence f32 reimplements floating point versions of the two main types, `Points` and `Rectangles`.
 
-- [op/clip](https://pkg.go.dev/gioui.org/op/clip) is used to define an area to paint within. Drawing outside this area is ignored.
+- [gioui.org/op/clip](https://pkg.go.dev/gioui.org/op/clip) is used to define an area to paint within. Drawing outside this area is ignored.
 
-- [op/paint](https://pkg.go.dev/gioui.org/op/paint) contains drawing operations to fill a shape with color.
+- [gioui.org/op/paint](https://pkg.go.dev/gioui.org/op/paint) contains drawing operations to fill a shape with color.
 
 ## Points and Rectangles
 
-Points and Rectangles are used extensively, so it's worth quoting from Nigel's blog mentioned above. Point's are coordinates and Rectangles are defined by Points:
+Points and Rectangles are used extensively, so it's worth quoting from Nigel's blog mentioned above. Points are coordinates and Rectangles are defined by Points:
 
 ```go
 type Point struct {


### PR DESCRIPTION
Fixed an extraneous apostrophe.
Made the imports explicit so that students will not have to figure out that "gioui.org/" has to be prepended for them to work.