### PR TITLE
docs: fix typos, grammar, and normalize indentation across egg timer chapters

### DIFF
--- a/egg_timer/01_empty_window.md
+++ b/egg_timer/01_empty_window.md
@@ -72,7 +72,7 @@ The code looks simple enough, right? Still, let's take the time to to look at wh
 
 3.  The **event loop** in the goroutine
 
-    - The event loop is the `for { wEvent() }` loop.
+    - The event loop is the `for { w.Event() }` loop.
       As described in the docs, [w.Event](https://pkg.go.dev/gioui.org/app#Window.Event) simply _blocks until an event is received from the window_. For now we just let it listen without doing anything with the events it receives. Later we'll start reacting to them.
 
       From [app.main](https://pkg.go.dev/gioui.org/app#hdr-Main) we learn:

--- a/egg_timer/01_empty_window.md
+++ b/egg_timer/01_empty_window.md
@@ -33,22 +33,21 @@ That's it! Let's look at the code:
 package main
 
 import (
-    "gioui.org/app"
+  "gioui.org/app"
 )
 
 func main() {
-    go func() {
-        // create new window
-        w := new(app.Window)
+  go func() {
+    // create new window
+    w := new(app.Window)
 
-        // listen for events in the window
-        for {
-            w.Event()
-        }
-    }()
-    app.Main()
+    // listen for events in the window
+    for {
+      w.Event()
+    }
+  }()
+  app.Main()
 }
-
 ```
 
 ## Comments
@@ -84,7 +83,7 @@ The code looks simple enough, right? Still, let's take the time to to look at wh
 
     ```go
     go func {
-    // ...
+      // ...
     }()
     ```
 

--- a/egg_timer/02_title_and_size.md
+++ b/egg_timer/02_title_and_size.md
@@ -36,13 +36,13 @@ import (
 func main() {
   go func() {
     // create new window
-		w := new(app.Window)
-		w.Option(app.Title("Egg timer"))
-		w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
+    w := new(app.Window)
+    w.Option(app.Title("Egg timer"))
+    w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
 
     // listen for events in the window
     for {
-        w.Event()
+      w.Event()
     }
   }()
   app.Main()

--- a/egg_timer/03_button.md
+++ b/egg_timer/03_button.md
@@ -124,7 +124,7 @@ func main() {
 - `th` is the material theme.
     -  Update in Gio 0.2 July 2023:
         - Gio now defaults to system fonts. This is great, one less thing to remember. However, should you want to flex your font skills, read the [July 2023 newsletter](https://gioui.org/news/2023-07).
-        - Also you may want to learn about Go's own dedicated high-quality True Type fonts? Read the [fascinating blog](https://blog.golang.org/go-fonts) and definetly visit [Bigelow & Holmes](https://bigelowandholmes.typepad.com), its creators. True old-school.
+        - Also you may want to learn about Go's own dedicated high-quality True Type fonts? Read the [fascinating blog](https://blog.golang.org/go-fonts) and definitely visit [Bigelow & Holmes](https://bigelowandholmes.typepad.com), its creators. True old-school.
 
 1. The `for` loop is more interesting. 
    - `w.Event()` blocks and waits for events. We store those as `evt`.

--- a/egg_timer/03_button.md
+++ b/egg_timer/03_button.md
@@ -32,13 +32,13 @@ To make things tidy, let's discuss imports first, then the main function later.
 
 ```go
 import (
-    "os"
+  "os"
 
-    "gioui.org/app"
-    "gioui.org/op"
-    "gioui.org/unit"
-    "gioui.org/widget"
-    "gioui.org/widget/material"
+  "gioui.org/app"
+  "gioui.org/op"
+  "gioui.org/unit"
+  "gioui.org/widget"
+  "gioui.org/widget/material"
 )
 ```
 
@@ -71,9 +71,9 @@ With imports well out of our way, let's look at the code. It's longer but still 
 func main() {
   go func() {
     // create new window
-		w := new(app.Window)
-		w.Option(app.Title("Egg timer"))
-		w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
+    w := new(app.Window)
+    w.Option(app.Title("Egg timer"))
+    w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
 
     // ops are the operations from the UI
     var ops op.Ops
@@ -86,23 +86,23 @@ func main() {
 
     // listen for events in the window.
     for {
-        // first grab the event
-        evt := w.Event()
+      // first grab the event
+      evt := w.Event()
 
-        // then detect the type
-        switch typ := evt.(type) {
+      // then detect the type
+      switch typ := evt.(type) {
 
-        // this is sent when the application should re-render.
-        case app.FrameEvent:
-            gtx := app.NewContext(&ops, typ)
-            btn := material.Button(th, &startButton, "Start")
-            btn.Layout(gtx)
-            typ.Frame(gtx.Ops)
+      // this is sent when the application should re-render.
+      case app.FrameEvent:
+        gtx := app.NewContext(&ops, typ)
+        btn := material.Button(th, &startButton, "Start")
+        btn.Layout(gtx)
+        typ.Frame(gtx.Ops)
 
-        // and this is sent when the application should exits
-        case app.DestroyEvent:
-            os.Exit(0)
-        }
+      // and this is sent when the application should exits
+      case app.DestroyEvent:
+        os.Exit(0)
+      }
     }
   }()
   app.Main()

--- a/egg_timer/04_button_low.md
+++ b/egg_timer/04_button_low.md
@@ -31,15 +31,15 @@ We start by removing a lot of the details to better see the structure:
 ```go
 case system.FrameEvent:
 
-    layout.Flex{
+  layout.Flex{
     // ...
-    }.Layout( // ...
-        // We insert two rigid elements:
-        // First one to hold a button ...
-        layout.Rigid(),
-        // .. then one to hold an empty spacer
-        layout.Rigid(),
-    }
+  }.Layout( // ...
+    // We insert two rigid elements:
+    // First one to hold a button ...
+    layout.Rigid(),
+    // .. then one to hold an empty spacer
+    layout.Rigid(),
+  }
 ```
 
 ### Comments
@@ -74,29 +74,29 @@ OK, that was the high level. Now it's time to dive deep. Let's look at the whole
 
 ```go
 case app.FrameEvent:
-    gtx := app.NewContext(&ops, typ)
-    // Let's try out the flexbox layout:
-    layout.Flex{
-        // Vertical alignment, from top to bottom
-        Axis: layout.Vertical,
-        // Empty space is left at the start, i.e. at the top
-        Spacing: layout.SpaceStart,
-    }.Layout(gtx,
-        // We insert two rigid elements:
-        // First one to hold a button ...
-        layout.Rigid(
-            func(gtx layout.Context) layout.Dimensions {
-                btn := material.Button(th, &startButton, "Start")
-                return btn.Layout(gtx)
-            },
-        ),
-        // ... then one to hold an empty spacer
-        layout.Rigid(
-            // The height of the spacer is 25 Device independent pixels
-            layout.Spacer{Height: unit.Dp(25)}.Layout,
-        ),
-    )
-    typ.Frame(gtx.Ops)
+  gtx := app.NewContext(&ops, typ)
+  // Let's try out the flexbox layout:
+  layout.Flex{
+    // Vertical alignment, from top to bottom
+    Axis: layout.Vertical,
+    // Empty space is left at the start, i.e. at the top
+    Spacing: layout.SpaceStart,
+  }.Layout(gtx,
+    // We insert two rigid elements:
+    // First one to hold a button ...
+    layout.Rigid(
+      func(gtx layout.Context) layout.Dimensions {
+        btn := material.Button(th, &startButton, "Start")
+        return btn.Layout(gtx)
+      },
+    ),
+    // ... then one to hold an empty spacer
+    layout.Rigid(
+        // The height of the spacer is 25 Device independent pixels
+        layout.Spacer{Height: unit.Dp(25)}.Layout,
+    ),
+  )
+  typ.Frame(gtx.Ops)
 ```
 
 ### Comments

--- a/egg_timer/05_button_low_refactored.md
+++ b/egg_timer/05_button_low_refactored.md
@@ -35,9 +35,9 @@ Main is too long and does too much. It's better if `main()` starts and controls 
 func main() {
   go func() {
     // create new window
-		w := new(app.Window)
-		w.Option(app.Title("Egg timer"))
-		w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
+    w := new(app.Window)
+    w.Option(app.Title("Egg timer"))
+    w.Option(app.Size(unit.Dp(400), unit.Dp(600)))
     if err := draw(w); err != nil {
       log.Fatal(err)
     }
@@ -70,21 +70,20 @@ A simplified version of `draw( )` shows the structure.
 
 ```go
 func draw(w *app.Window) error {
-    // ...
+  // ...
 
-    // listen for events in the window.
-    for {
-        // detect what type of event
-        switch e := w.Event().(type) {
+  // listen for events in the window.
+  for {
+    // detect what type of event
+    switch e := w.Event().(type) {
 
-        // this is sent when the application should re-render.
-        case app.FrameEvent:
-            // ...
+    // this is sent when the application should re-render.
+    case app.FrameEvent:
+      // ...
 
-        // this is sent when the application is closed
-        case app.DestroyEvent:
-            return e.Err
-        }
+    // this is sent when the application is closed
+    case app.DestroyEvent:
+      return e.Err
     }
 }
 ```

--- a/egg_timer/05_button_low_refactored.md
+++ b/egg_timer/05_button_low_refactored.md
@@ -18,7 +18,7 @@ The intent of this section is to organize the code better.
 
 Up to now, we've built the program by bolting on functionality, bit by bit. This has served us well, allowing us to start with an empty canvas, iterate by changing the minimum amount of lines, while still making meaningful progress.
 
-Going forward however, it's starting to look a little unwieldy. Having all the code inside one big `main()` is can make it harder to understand, and harder to continue building. Hence we'll refactor the program a bit, simply breaking it up into smaller pieces.
+Going forward however, it's starting to look a little unwieldy. Having all the code inside one big `main()` can make it harder to understand, and harder to continue building. Hence we'll refactor the program a bit, simply breaking it up into smaller pieces.
 
 > _Refactoring is transforming code in a safe and rapid way is vital to keeping it cheap and easy to modify for future needs._
 > [Martin Fowler](https://martinfowler.com/books/refactoring.html)
@@ -88,7 +88,7 @@ func draw(w *app.Window) error {
 }
 ```
 
-As before examine all events. But since all we really care about is the type, let's simplify to `e: = w.Event().(type)`, to detect the type.
+As before examine all events. But since all we really care about is the type, let's simplify to `e := w.Event().(type)`, to detect the type.
 
 - `app.FrameEvent` is handled as before,
 - we tidy the case for `app.DestroyEvent`, which returns _nil_ for normal window closures, but _Err_ if something else is the cause. The draw function should only inform what's been detected, not call the `os` directly.

--- a/egg_timer/06_button_low_margin.md
+++ b/egg_timer/06_button_low_margin.md
@@ -31,31 +31,26 @@ There are really only three key lines here:
 
 ```go
 layout.Flex{
-    // ...
+  // ...
 }.Layout(gtx,
-    layout.Rigid(
+	layout.Rigid(
+    func(gtx C) D {
+      // ONE: First define margins around the button using layout.Inset ...
+      margins := layout.Inset{
+        // ...
+      }
+
+      // TWO: ... then we lay out those margins ...
+      margins.Layout(
+        // THREE: ... and finally within the margins, we define and lay out the button
         func(gtx C) D {
-            // ONE: First define margins around the button using layout.Inset ...
-            margins := layout.Inset{
-                // ...
-            }
-
-            // TWO: ... then we lay out those margins ...
-            margins.Layout(
-
-                // THREE: ... and finally within the margins, we define and lay out the button
-                func(gtx C) D {
-                    btn := material.Button(th, &startButton, "Start")
-                    return btn.Layout(gtx)
-                },
-
-            )
-
-            }
-        }
-    )
+          btn := material.Button(th, &startButton, "Start")
+          return btn.Layout(gtx)
+        },
+      )
+    }
+  )
 )
-
 ```
 
 ## Comments
@@ -68,10 +63,10 @@ The margins are made using [layout.Inset{ }](https://pkg.go.dev/gioui.org/layout
 
 ```go
 margins := layout.Inset{
-    Top:    unit.Dp(25),
-    Bottom: unit.Dp(25),
-    Right:  unit.Dp(35),
-    Left:   unit.Dp(35),
+  Top:    unit.Dp(25),
+  Bottom: unit.Dp(25),
+  Right:  unit.Dp(35),
+  Left:   unit.Dp(35),
 }
 ```
 
@@ -83,36 +78,35 @@ To wrap it all up, here's the code for the whole `app.FrameEvent`
 
 ```go
 case app.FrameEvent:
-    gtx := app.NewContext(&ops, e)
-    // Let's try out the flexbox layout concept
-    layout.Flex{
-        // Vertical alignment, from top to bottom
-        Axis: layout.Vertical,
-        // Empty space is left at the start, i.e. at the top
-        Spacing: layout.SpaceStart,
-    }.Layout(gtx,
-        layout.Rigid(
-            func(gtx C) D {
-                // ONE: First define margins around the button using layout.Inset ...
-                margins := layout.Inset{
-                    Top:    unit.Dp(25),
-                    Bottom: unit.Dp(25),
-                    Right:  unit.Dp(35),
-                    Left:   unit.Dp(35),
-                }
-                // TWO: ... then we lay out those margins ...
-                return margins.Layout(gtx,
-                    // THREE: ... and finally within the margins, we ddefine and lay out the button
-                    func(gtx C) D {
-                        btn := material.Button(th, &startButton, "Start")
-                        return btn.Layout(gtx)
-                    },
-                )
-            },
-        ),
-    )
-    e.Frame(gtx.Ops)
-
+  gtx := app.NewContext(&ops, e)
+  // Let's try out the flexbox layout concept
+  layout.Flex{
+    // Vertical alignment, from top to bottom
+    Axis: layout.Vertical,
+    // Empty space is left at the start, i.e. at the top
+    Spacing: layout.SpaceStart,
+  }.Layout(gtx,
+    layout.Rigid(
+      func(gtx C) D {
+        // ONE: First define margins around the button using layout.Inset ...
+        margins := layout.Inset{
+          Top:    unit.Dp(25),
+          Bottom: unit.Dp(25),
+          Right:  unit.Dp(35),
+          Left:   unit.Dp(35),
+        }
+        // TWO: ... then we lay out those margins ...
+        return margins.Layout(gtx,
+          // THREE: ... and finally within the margins, we ddefine and lay out the button
+          func(gtx C) D {
+            btn := material.Button(th, &startButton, "Start")
+            return btn.Layout(gtx)
+          },
+        )
+      },
+    ),
+  )
+  e.Frame(gtx.Ops)
 ```
 
 ---

--- a/egg_timer/07_progressbar.md
+++ b/egg_timer/07_progressbar.md
@@ -52,7 +52,6 @@ layout.Flex{
       return bar.Layout(gtx)
     },
   ),
-
 ```
 
 Notice how the widget itself has no state. State is maintained in the rest of the program, the widget only knows how to display the progress we send it. Any logic to increase, pause, reverse or reset we control outside the widget.

--- a/egg_timer/07_progressbar.md
+++ b/egg_timer/07_progressbar.md
@@ -138,7 +138,7 @@ go func() {
 
 Here we start up an anonymous function to listen to the `progressIncrementer` channel. This is a concurrency feature of Go. Create a listener and let it do its thing. For us, that thing is to add `p` to `progress` if the control variable `boiling` is true, and progress is less than 1. Since `p` is 0.004, and progress increased 25 times per second, it will take 10 seconds to reach 1. Feel free to adjust either of these two to find a combination of speed and smoothness that works for you.
 
-Finally we force the window to draw, by calling `w.Invalidate()`. What is does is to inform Gio that the old rendering is now, well, invalid, and hence a new drawing must be made. Without such notice, Gio would simply not update until forced to do so by a mouse click or button press or other events. Invalidating at _every_ frame though can be costly, and alternatives exists. It's a bit of an advanced topic though, so for now let's leave it as is, but return to it in the [Bonus chapter on improved animation](11_improved_animation.md).
+Finally we force the window to draw, by calling `w.Invalidate()`. What it does is inform Gio that the old rendering is now, well, invalid, and hence a new drawing must be made. Without such notice, Gio would simply not update until forced to do so by a mouse click or button press or other events. Invalidating at _every_ frame though can be costly, and alternatives exists. It's a bit of an advanced topic though, so for now let's leave it as is, but return to it in the [Bonus chapter on improved animation](11_improved_animation.md).
 
 By using a channel like this we get
 

--- a/egg_timer/08_egg_as_circle.md
+++ b/egg_timer/08_egg_as_circle.md
@@ -97,9 +97,9 @@ layout.Rigid(
 
 We first define a circle using `clip.Ellipse{ }`. It defines circle as an `Ellipse` within a box, where the dimensions of the box are specified by the top left and bottom right corners. `Min` and `Max` respectively.
 
-By choice there are two versions of `Min`and `Max`. One is hard coded, just to show how `image.Pt( )` works. But that might not necessarily be what you want - try it for yourself by changing what's commented in and out and resize the window. 
+By choice there are two versions of `Min` and `Max`. One is hard coded, just to show how `image.Pt( )` works. But that might not necessarily be what you want - try it for yourself by changing what's commented in and out and resize the window.
 
-Instead, dynamic positioning based on `gtx.Constraints` adapts to the window. Play around with these dimensions, familiarize yourself with when the circle moves up or down, depending in wheiter you resize the window or move the limiting box around the Ellipse.
+Instead, dynamic positioning based on `gtx.Constraints` adapts to the window. Play around with these dimensions, familiarize yourself with when the circle moves up or down, depending on wheter you resize the window or move the limiting box around the Ellipse.
 
 **Gotcha:** If you are lucky enough to work with a High DPI display, and happen to run it with a scaling factor of, say 125%, another problem with the hard coded coordinates will surface. Gio works well with `Dp`, **D**isplay independent **p**ixels, which ensures that 1 Dp will have the same apparent size across displays and resolutions. When hard-coding like here, that dynamic is overruled. A 125% resolution scale will translate the **400 Dp** wide window (as defined in `app.NewWindow`) into a **500 pixels** context. You can see this by inspecting `gtx.Constraints` and convert pixels to Dp by `gtx.Dp()`. 
 

--- a/egg_timer/08_egg_as_circle.md
+++ b/egg_timer/08_egg_as_circle.md
@@ -44,11 +44,11 @@ Points and Rectangles are used extensively, so it's worth quoting from Nigel's b
 
 ```go
 type Point struct {
-    X, Y float32
+  X, Y float32
 }
 
 type Rectangle struct {
-    Min, Max Point
+  Min, Max Point
 }
 ```
 
@@ -78,12 +78,12 @@ That's it. Let's look at the code:
 layout.Rigid(
   func(gtx C) D {
     circle := clip.Ellipse{
-       // Hard coding the x coordinate. Try resizing the window
-       // Min: image.Pt(80, 0),
-       // Max: image.Pt(320, 240),
-       // Soft coding the x coordinate. Try resizing the window
-       Min: image.Pt(gtx.Constraints.Max.X/2-120, 0),
-       Max: image.Pt(gtx.Constraints.Max.X/2+120, 240),
+      // Hard coding the x coordinate. Try resizing the window
+      // Min: image.Pt(80, 0),
+      // Max: image.Pt(320, 240),
+      // Soft coding the x coordinate. Try resizing the window
+      Min: image.Pt(gtx.Constraints.Max.X/2-120, 0),
+      Max: image.Pt(gtx.Constraints.Max.X/2+120, 240),
     }.Op(gtx.Ops)
     color := color.NRGBA{R: 200, A: 255}
     paint.FillShape(gtx.Ops, color, circle)

--- a/egg_timer/09_egg_as_egg.md
+++ b/egg_timer/09_egg_as_egg.md
@@ -33,7 +33,6 @@ layout.Rigid(
     eggPath.Begin(gtx.Ops)
     // Rotate from 0 to 360 degrees
     for deg := 0.0; deg <= 360; deg++ {
-
       // Egg math (really) at this brilliant site. Thanks!
       // https://observablehq.com/@toja/egg-curve
       // Convert degrees to radians

--- a/egg_timer/10_input_boiltime.md
+++ b/egg_timer/10_input_boiltime.md
@@ -56,11 +56,11 @@ The editor widget is the input field where the chef can input how long the egg s
 
 **Some variables for the editor**
 
-Just as for the button, we need a variable for the inputfield itself. So we start by declaring a [widget.Editor](https://pkg.go.dev/gioui.org/widget#Editor) variable.
+Just as for the button, we need a variable for the input field itself. So we start by declaring a [widget.Editor](https://pkg.go.dev/gioui.org/widget#Editor) variable.
 
-We also create a variable to hold the actual numerical value in the inputfield and call it `boilDuration`. Note that there is no magical link between these variables, but we will later write code that reads from the input field, and stores the values in the `boilDuration`. All in due time though.
+We also create a variable to hold the actual numerical value in the input field and call it `boilDuration`. Note that there is no magical link between these variables, but we will later write code that reads from the input field, and stores the values in the `boilDuration`. All in due time though.
 
-With these, we now in the top of our `draw()` function find the following lines:
+With these changes, we now find the following lines at the top of our `draw()` function:
 
 ```go
 // boilDurationInput is a textfield to input boil duration
@@ -73,7 +73,7 @@ var boilDuration float32
 
 ### 3. Update boil-status and read from the inputbox
 
-The only time we really need to check what is written in the inputbox is when the user clicks the start button. Hence we put the logic inside that `if{ }` block. Naturally that's also where we control the `boiling` boolean. Boil bool, boil bool, boil bool - that's a toungue twister (sorry, I know). 
+The only time we really need to check what is written in the inputbox is when the user clicks the start button. Hence we put the logic inside that `if` block. Naturally that's also where we control the `boiling` boolean. Boil bool, boil bool, boil bool - that's a tongue twister (sorry, I know).
 
 A simple progress check allows us to restart a fresh boil when the first has completed. Thus the code reads:
 
@@ -144,7 +144,7 @@ Now that we have the overview in place let's examine that second rigid in detail
 
 **Editor with theme**
 
-We start by wrapping the `boilDurationInput` variable in the Material Design theme. We take the occation to add a [hint](https://pkg.go.dev/gioui.org/widget/material#EditorStyle)
+We start by wrapping the `boilDurationInput` variable in the Material Design theme. We take the occasion to add a [hint](https://pkg.go.dev/gioui.org/widget/material#EditorStyle)
 
 ```go
 // The inputbox
@@ -181,7 +181,7 @@ if boiling && progress < 1 {
 }
 ```
 
-When we are in the middle of a boil, we here define a new `boilRemain` that holds the remaining time until the boil is complete, calculated using `(1-progress`)
+When we are in the middle of a boil, we define a new `boilRemain` that holds the remaining time until the boil is complete, calculated using `(1 - progress)`
 
 Since [math.Round()](https://pkg.go.dev/math#Round) doesn't allow rounding to a given number of decimals, we must use a trick.
 
@@ -280,9 +280,9 @@ More bells and whistles could be added here. Might I for example challenge you t
 
 And that's it. Thank you for coming along and I hope you've been tempted to try your hand at GUI development.
 
-We've only scratched the surface, and there's much more capability in the framework than we've exposed here. But, now that we have ve boiled that egg together, we've come quite far as well, right? Now, can I ask something of you?
+We've only scratched the surface, and there's much more capability in the framework than we've exposed here. But, now that we have boiled that egg together, we've come quite far as well, right? Now, can I ask something of you?
 
-If you liked what you've read, please star it on Github. I'm only human, and honestly it's tremedously motivating to receive those tokens of appreciation.
+If you liked what you've read, please star it on Github. I'm only human, and honestly it's tremendously motivating to receive those tokens of appreciation.
 
 And ~~if~~ when you get started on your own project, big or small, please drop me a line. I would love to hear from you.
 

--- a/egg_timer/10_input_boiltime.md
+++ b/egg_timer/10_input_boiltime.md
@@ -63,12 +63,12 @@ We also create a variable to hold the actual numerical value in the inputfield a
 With these, we now in the top of our `draw()` function find the following lines:
 
 ```go
-  // boilDurationInput is a textfield to input boil duration
-  var boilDurationInput widget.Editor
+// boilDurationInput is a textfield to input boil duration
+var boilDurationInput widget.Editor
 
-  // is the egg boiling?
-  var boiling bool
-  var boilDuration float32
+// is the egg boiling?
+var boiling bool
+var boilDuration float32
 ```
 
 ### 3. Update boil-status and read from the inputbox
@@ -159,9 +159,9 @@ layout.Rigid(
 At this point, the `boilDurationInput` is still just an empty field, so we will do some configuration:
 
 ```go
-    // Define characteristics of the input box
-    boilDurationInput.SingleLine = true
-    boilDurationInput.Alignment = text.Middle
+// Define characteristics of the input box
+boilDurationInput.SingleLine = true
+boilDurationInput.Alignment = text.Middle
 ```
 
 - `SingleLine` forces the box to always be one line high. Without it, the box will grow when the user presses enter

--- a/egg_timer/11_improved_animation.md
+++ b/egg_timer/11_improved_animation.md
@@ -44,15 +44,15 @@ There are two alternatives, let's look at both:
 Remember how the progress bar is one of the rigids we lay out:
 
 ```go
-  // PREVIOUS CODE
+// PREVIOUS CODE
 
-  // The progressbar
-  layout.Rigid(
-    func(gtx C) D {
-      bar := material.ProgressBar(th, progress)
-      return bar.Layout(gtx)
-    },
-  ),
+// The progressbar
+layout.Rigid(
+  func(gtx C) D {
+    bar := material.ProgressBar(th, progress)
+    return bar.Layout(gtx)
+},
+),
 ```
 
 We now expand that with its own personal timing logic: 
@@ -98,18 +98,18 @@ func draw(w *app.Window) error {
   // ...
 
   // listen for events in the incrementor channel
-    go func() {
-      for range progressIncrementer {
-        if boiling && progress < 1 {
-          progress += 1.0 / 25.0 / boilDuration
-          if progress >= 1 {
-            progress = 1
-          }
-          // Force a redraw by invalidating the frame
-          // w.Invalidate() // This is replaced by op.InvalidateCmd for the progressbar on line 211
+  go func() {
+    for range progressIncrementer {
+      if boiling && progress < 1 {
+        progress += 1.0 / 25.0 / boilDuration
+        if progress >= 1 {
+          progress = 1
         }
+        // Force a redraw by invalidating the frame
+        // w.Invalidate() // This is replaced by op.InvalidateCmd for the progressbar on line 211
       }
-    }()
+    }
+  }()
 ```
 
 ### 3. - Replacing w.Invalidate() with op.InvalidateCmd{} - what's the effect
@@ -179,7 +179,6 @@ func (a animation) progress(gtx layout.Context) (animating bool, progress float3
   op.InvalidateOp{}.Add(gtx.Ops)
   return true, float32(gtx.Now.Sub(a.start)) / float32(a.duration)
 }
-
 ```
 
 #### Start simplifying
@@ -203,7 +202,6 @@ case system.FrameEvent:
       anim.animate(gtx, time.Duration(inputFloat)*time.Second)
     }
   }
-
 ```
 
 #### Tidy up the loose end


### PR DESCRIPTION
## Summary

- Normalize code block indentation to 2-space style across chapters 01–11
- Fix typos: `definetly`, `occation`, `wheiter`, `toungue`, `tremedously`
- Fix grammar and wording issues (duplicate words, awkward phrasing)
- Fix broken code references: `wEvent()` → `w.Event()`, `e: =` → `e :=`
